### PR TITLE
Update repository guidelines

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        python3 \
+        python3-pip \
+        gcc-arm-none-eabi \
+        gdb-multiarch \
+        scons \
+    && rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "RT-Thread 5.0.0",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "extensions": [
+        "ms-vscode.cpptools"
+    ],
+    "remoteUser": "root"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Guidelines
+
+* Keep comments and documentation in English.
+* After modifying the development container files, verify the build with:
+
+  ```sh
+  docker build -t rtos-dev -f .devcontainer/Dockerfile .
+  ```


### PR DESCRIPTION
## Summary
- configure RT-Thread 5.0.0 devcontainer on Ubuntu 22.04
- provide instructions for verifying the build
- remove note about including build output in PR descriptions

## Testing
- `docker --version` *(fails: command not found)*
- `docker build -t rtos-dev -f .devcontainer/Dockerfile .` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.