### PR TITLE
Add cortex-m7 test BSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ bash qemu-nographic.sh
 ```
 
 The script starts `qemu-system-arm` in headless mode and boots the `rtthread.bin` image. Once the boot process finishes you should see the RT-Thread shell prompt in the terminal. If no output appears, ensure `BSP_USING_UART0` is enabled in `.config` and rebuild.
+
+## Minimal Cortex-M7 BSP
+
+A lightweight BSP using QEMU's `mps2-an500` machine (qemu-cortex-m7-test) is also available. Build it with:
+
+```bash
+cd rt-thread/bsp/qemu-cortex-m7-test
+scons -j$(nproc)
+```
+
+Run the image with:
+
+```bash
+cd rt-thread/bsp/qemu-cortex-m7-test
+./qemu-nographic.sh
+```
+
+The board will boot and print the RT-Thread banner on the serial console.

--- a/rt-thread/bsp/qemu-cortex-m7-test/Kconfig
+++ b/rt-thread/bsp/qemu-cortex-m7-test/Kconfig
@@ -1,0 +1,11 @@
+mainmenu "RT-Thread Project Configuration"
+
+BSP_DIR := .
+
+RTT_DIR := ../..
+
+PKGS_DIR := packages
+
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/rt-thread/bsp/qemu-cortex-m7-test/README.md
+++ b/rt-thread/bsp/qemu-cortex-m7-test/README.md
@@ -1,0 +1,21 @@
+# QEMU Cortex-M7 Test BSP
+
+This board support package targets the `mps2-an500` machine in QEMU which emulates a Cortex-M7 CPU. The configuration is minimal and only enables a single UART for console output.
+
+## Building
+
+```bash
+cd rt-thread/bsp/qemu-cortex-m7-test
+scons -j$(nproc)
+```
+
+The resulting `rtthread.bin` image can then be executed with QEMU.
+
+## Running
+
+```bash
+cd rt-thread/bsp/qemu-cortex-m7-test
+./qemu-nographic.sh
+```
+
+After the system boots you should see the RT-Thread shell on the terminal.

--- a/rt-thread/bsp/qemu-cortex-m7-test/SConscript
+++ b/rt-thread/bsp/qemu-cortex-m7-test/SConscript
@@ -1,0 +1,13 @@
+import os
+from building import *
+
+cwd = GetCurrentDir()
+objs = []
+list = os.listdir(cwd)
+
+for d in list:
+    path = os.path.join(cwd, d)
+    if os.path.isfile(os.path.join(path, 'SConscript')):
+        objs = objs + SConscript(os.path.join(d, 'SConscript'))
+
+Return('objs')

--- a/rt-thread/bsp/qemu-cortex-m7-test/SConstruct
+++ b/rt-thread/bsp/qemu-cortex-m7-test/SConstruct
@@ -1,0 +1,29 @@
+import os
+import sys
+import rtconfig
+
+if os.getenv('RTT_ROOT'):
+    RTT_ROOT = os.getenv('RTT_ROOT')
+else:
+    RTT_ROOT = os.path.join(os.getcwd(), '..', '..')
+
+sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+from building import *
+
+TARGET = 'rtthread.' + rtconfig.TARGET_EXT
+
+DefaultEnvironment(tools=[])
+env = Environment(tools=['mingw'],
+    AS=rtconfig.AS, ASFLAGS=rtconfig.AFLAGS,
+    CC=rtconfig.CC, CFLAGS=rtconfig.CFLAGS,
+    AR=rtconfig.AR, ARFLAGS='-rc',
+    LINK=rtconfig.LINK, LINKFLAGS=rtconfig.LFLAGS)
+env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
+env['ASCOM'] = env['ASPPCOM']
+
+Export('RTT_ROOT')
+Export('rtconfig')
+
+objs = PrepareBuilding(env, RTT_ROOT)
+
+DoBuilding(TARGET, objs)

--- a/rt-thread/bsp/qemu-cortex-m7-test/applications/SConscript
+++ b/rt-thread/bsp/qemu-cortex-m7-test/applications/SConscript
@@ -1,0 +1,9 @@
+from building import *
+
+cwd = GetCurrentDir()
+src = Glob('*.c')
+CPPPATH = [cwd]
+
+group = DefineGroup('Applications', src, depend=[''], CPPPATH=CPPPATH)
+
+Return('group')

--- a/rt-thread/bsp/qemu-cortex-m7-test/applications/main.c
+++ b/rt-thread/bsp/qemu-cortex-m7-test/applications/main.c
@@ -1,0 +1,8 @@
+#include <rtthread.h>
+#include <stdio.h>
+
+int main(void)
+{
+    extern int rtthread_startup(void);
+    return rtthread_startup();
+}

--- a/rt-thread/bsp/qemu-cortex-m7-test/drivers/Kconfig
+++ b/rt-thread/bsp/qemu-cortex-m7-test/drivers/Kconfig
@@ -1,0 +1,22 @@
+menu "Hardware Drivers Config"
+
+config SOC_MPS2_AN500
+    bool
+    select ARCH_ARM_CORTEX_M7
+    select RT_USING_COMPONENTS_INIT
+    select RT_USING_USER_MAIN
+    default y
+
+menu "Onboard Peripheral Drivers"
+    menuconfig BSP_USING_UART
+        bool "Enable UART"
+        default y
+        select RT_USING_SERIAL
+        if BSP_USING_UART
+            config BSP_USING_UART0
+                bool "Enable UART0 (Debugger)"
+                default y
+        endif
+endmenu
+
+endmenu

--- a/rt-thread/bsp/qemu-cortex-m7-test/drivers/SConscript
+++ b/rt-thread/bsp/qemu-cortex-m7-test/drivers/SConscript
@@ -1,0 +1,9 @@
+from building import *
+
+cwd = GetCurrentDir()
+src = Glob('*.c') + Glob('../startup_gcc.S')
+CPPPATH = [cwd]
+
+group = DefineGroup('Drivers', src, depend=[''], CPPPATH=CPPPATH)
+
+Return('group')

--- a/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.c
+++ b/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.c
@@ -1,0 +1,52 @@
+#include <rthw.h>
+#include <rtthread.h>
+#include "board.h"
+
+#define SYST_CSR   (*(volatile uint32_t*)0xE000E010)
+#define SYST_RVR   (*(volatile uint32_t*)0xE000E014)
+#define SYST_CVR   (*(volatile uint32_t*)0xE000E018)
+
+#ifndef SYSTEM_CORE_CLOCK
+#define SYSTEM_CORE_CLOCK 100000000
+#endif
+static uint32_t SystemCoreClock = SYSTEM_CORE_CLOCK;
+
+#define UART0_BASE 0x40004000
+#define UART0_DR   (*(volatile uint32_t*)(UART0_BASE + 0x0))
+#define UART0_STATE (*(volatile uint32_t*)(UART0_BASE + 0x4))
+#define UART0_TXFULL (1 << 0)
+
+void rt_hw_console_output(const char *str)
+{
+    while (*str)
+    {
+        while (UART0_STATE & UART0_TXFULL)
+            ;
+        UART0_DR = *str++;
+    }
+}
+
+void SysTick_Handler(void)
+{
+    rt_interrupt_enter();
+    rt_tick_increase();
+    rt_interrupt_leave();
+}
+
+void rt_hw_board_init(void)
+{
+#ifdef RT_USING_HEAP
+    rt_system_heap_init(HEAP_BEGIN, HEAP_END);
+#endif
+
+    SYST_RVR = SystemCoreClock / RT_TICK_PER_SECOND - 1;
+    SYST_CVR = 0;
+    SYST_CSR = 7;
+
+#ifdef RT_USING_CONSOLE
+    rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
+#ifdef RT_USING_COMPONENTS_INIT
+    rt_components_board_init();
+#endif
+}

--- a/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.h
+++ b/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.h
@@ -1,0 +1,14 @@
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+#include <rtconfig.h>
+#include <stdint.h>
+
+extern unsigned int __bss_end;
+
+#define HEAP_BEGIN ((void *)&__bss_end)
+#define HEAP_END   ((void *)0x20080000)
+
+void rt_hw_board_init(void);
+
+#endif

--- a/rt-thread/bsp/qemu-cortex-m7-test/link.lds
+++ b/rt-thread/bsp/qemu-cortex-m7-test/link.lds
@@ -1,0 +1,111 @@
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+ENTRY(Reset_Handler)
+SECTIONS
+{
+    . = 0x00000000;
+
+    __text_start = .;
+    .text :
+    {
+        KEEP(*(.vectors))
+        *(.text)
+        *(.text.*)
+
+        /* section information for utest */
+        . = ALIGN(4);
+        __rt_utest_tc_tab_start = .;
+        KEEP(*(UtestTcTab))
+        __rt_utest_tc_tab_end = .;
+
+        /* section information for finsh shell */
+        . = ALIGN(4);
+        __fsymtab_start = .;
+        KEEP(*(FSymTab))
+        __fsymtab_end = .;
+        . = ALIGN(4);
+        __vsymtab_start = .;
+        KEEP(*(VSymTab))
+        __vsymtab_end = .;
+
+        /* section information for var export */
+        . = ALIGN(4);
+        __ve_table_start = .;
+        KEEP(*(SORT(*.VarExpTab.*)))
+        __ve_table_end = .;
+
+        /* section information for modules */
+        . = ALIGN(4);
+        __rtmsymtab_start = .;
+        KEEP(*(RTMSymTab))
+        __rtmsymtab_end = .;
+
+        /* section information for initialization */
+        . = ALIGN(4);
+        __rt_init_start = .;
+        KEEP(*(SORT(.rti_fn*)))
+        __rt_init_end = .;
+    } =0
+    __text_end = .;
+
+    .ARM.exidx   :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+    }
+
+    __rodata_start = .;
+    .rodata   : { *(.rodata) *(.rodata.*) }
+    __rodata_end = .;
+
+    . = ALIGN(4);
+    .ctors :
+    {
+        PROVIDE(__ctors_start__ = .);
+        /* new GCC version uses .init_array */
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE(__ctors_end__ = .);
+    }
+
+    .dtors :
+    {
+        PROVIDE(__dtors_start__ = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE(__dtors_end__ = .);
+    }
+
+    . = ALIGN(8);
+    __data_start = .;
+    .data :
+    {
+        *(.data)
+        *(.data.*)
+    }
+    __data_end = .;
+
+    . = ALIGN(4);
+    __bss_start = .;
+    .bss       :
+    {
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    }
+    . = ALIGN(4);
+    __bss_end = .;
+
+    /* Stabs debugging sections.  */
+    .stab 0 : { *(.stab) }
+    .stabstr 0 : { *(.stabstr) }
+    .stab.excl 0 : { *(.stab.excl) }
+    .stab.exclstr 0 : { *(.stab.exclstr) }
+    .stab.index 0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 : { *(.comment) }
+
+    _end = .;
+}

--- a/rt-thread/bsp/qemu-cortex-m7-test/qemu-nographic.sh
+++ b/rt-thread/bsp/qemu-cortex-m7-test/qemu-nographic.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+qemu-system-arm -M mps2-an500 -kernel rtthread.bin -nographic -serial mon:stdio

--- a/rt-thread/bsp/qemu-cortex-m7-test/rtconfig.h
+++ b/rt-thread/bsp/qemu-cortex-m7-test/rtconfig.h
@@ -1,0 +1,33 @@
+#ifndef RT_CONFIG_H__
+#define RT_CONFIG_H__
+
+/* RT-Thread Kernel */
+#define RT_CPUS_NR 1
+#define RT_NAME_MAX 16
+#define RT_ALIGN_SIZE 4
+#define RT_THREAD_PRIORITY_32
+#define RT_THREAD_PRIORITY_MAX 32
+#define RT_TICK_PER_SECOND 100
+#define RT_USING_OVERFLOW_CHECK
+#define RT_USING_HEAP
+#define RT_USING_COMPONENTS_INIT
+#define IDLE_THREAD_STACK_SIZE 512
+#define RT_CONSOLEBUF_SIZE 256
+#define RT_BACKTRACE_LEVEL_MAX_NR 32
+#define RT_USING_USER_MAIN
+#define RT_MAIN_THREAD_STACK_SIZE 2048
+
+/* Device drivers */
+#define RT_USING_DEVICE
+#define RT_USING_CONSOLE
+#define RT_CONSOLE_DEVICE_NAME "uart0"
+
+/* Shell */
+
+/* Drivers */
+#define BSP_USING_UART
+#define BSP_USING_UART0
+
+#define SOC_MPS2_AN500
+
+#endif

--- a/rt-thread/bsp/qemu-cortex-m7-test/rtconfig.py
+++ b/rt-thread/bsp/qemu-cortex-m7-test/rtconfig.py
@@ -1,0 +1,33 @@
+import os
+
+ARCH = 'arm'
+CPU = 'cortex-m7'
+CROSS_TOOL = 'gcc'
+PLATFORM = 'gcc'
+EXEC_PATH = os.getenv('RTT_EXEC_PATH') or '/usr/bin'
+BUILD = 'debug'
+LINK_SCRIPT = 'link.lds'
+
+if PLATFORM == 'gcc':
+    PREFIX = os.getenv('RTT_CC_PREFIX') or 'arm-none-eabi-'
+    CC = PREFIX + 'gcc'
+    CXX = PREFIX + 'g++'
+    AS = PREFIX + 'gcc'
+    AR = PREFIX + 'ar'
+    LINK = PREFIX + 'gcc'
+    TARGET_EXT = 'elf'
+    SIZE = PREFIX + 'size'
+    OBJDUMP = PREFIX + 'objdump'
+    OBJCPY = PREFIX + 'objcopy'
+    STRIP = PREFIX + 'strip'
+    DEVICE = ' -mcpu=cortex-m7 -mthumb '
+    CFLAGS = DEVICE + '-Wall -Wno-cpp -std=gnu99 -ffunction-sections -fdata-sections'
+    AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp'
+    LFLAGS = DEVICE + ' -nostartfiles -nostdlib -Wl,--gc-sections,-Map=rtthread.map,-e,Reset_Handler -T ' + LINK_SCRIPT + ' -lc -lgcc'
+    if BUILD == 'debug':
+        CFLAGS += ' -O0 -g'
+        AFLAGS += ' -g'
+    else:
+        CFLAGS += ' -Os'
+
+    POST_ACTION = OBJCPY + ' -O binary $TARGET rtthread.bin\n' + SIZE + ' $TARGET\n'

--- a/rt-thread/bsp/qemu-cortex-m7-test/startup_gcc.S
+++ b/rt-thread/bsp/qemu-cortex-m7-test/startup_gcc.S
@@ -1,0 +1,70 @@
+.syntax unified
+.cpu cortex-m7
+.thumb
+
+.global Reset_Handler
+.global __StackTop
+
+.section .vectors, "a"
+__StackTop = 0x20080000
+
+Vectors:
+    .word __StackTop
+    .word Reset_Handler
+    .word NMI_Handler
+    .word HardFault_Handler
+    .word MemManage_Handler
+    .word BusFault_Handler
+    .word UsageFault_Handler
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word SVC_Handler
+    .word DebugMon_Handler
+    .word 0
+    .word PendSV_Handler
+    .word SysTick_Handler
+
+    .size Vectors, .-Vectors
+
+    .section .text.Reset_Handler
+    .weak NMI_Handler
+    .weak HardFault_Handler
+    .weak MemManage_Handler
+    .weak BusFault_Handler
+    .weak UsageFault_Handler
+    .weak SVC_Handler
+    .weak DebugMon_Handler
+    .weak PendSV_Handler
+
+NMI_Handler:
+    b .
+HardFault_Handler:
+    b .
+MemManage_Handler:
+    b .
+BusFault_Handler:
+    b .
+UsageFault_Handler:
+    b .
+SVC_Handler:
+    b .
+DebugMon_Handler:
+    b .
+PendSV_Handler:
+    b .
+
+Reset_Handler:
+    /* Clear .bss */
+    ldr r0, =__bss_start
+    ldr r1, =__bss_end
+    movs r2, #0
+1:
+    cmp r0, r1
+    it lt
+    strlt r2, [r0], #4
+    blt 1b
+
+    bl entry
+    b .


### PR DESCRIPTION
## Summary
- rename mps2-an500 BSP to `qemu-cortex-m7-test`
- implement bare-metal startup code and UART console output
- document new BSP name in repository README

## Testing
- `scons -j2` in `rt-thread/bsp/qemu-cortex-m7-test`
- `timeout 5 qemu-system-arm -M mps2-an500 -kernel rtthread.bin -nographic -serial mon:stdio` *(no serial output)*
