### PR TITLE
Improve board init for mps2-an500

### DIFF
--- a/ERROR_REPORT.md
+++ b/ERROR_REPORT.md
@@ -1,0 +1,18 @@
+# QEMU Cortex-M7 Test Failure
+
+## Steps Performed
+1. Built the firmware for `qemu-cortex-m7-test` using `scons -j$(nproc)`.
+2. Ran the image with `qemu-system-arm -M mps2-an500 -kernel rtthread.bin -nographic -serial mon:stdio` as documented.
+3. Observed that QEMU executed but no output was produced on the console.
+4. Tried variations including additional QEMU options (`-cpu cortex-m7`, `-semihosting`, debug flags) and captured logs. No RT-Thread banner or `Hello RT-Thread` message appeared.
+5. Verified that build artifacts were generated correctly and checked UART initialization code in `board.c`.
+
+## Unresolved Issues
+- QEMU runs without errors but produces no serial output. Debugging with GDB shows execution reaches `rt_hw_console_output`.
+- UART registers at `0x40004008` and `0x40004010` remain zero even after attempting to enable the clock and reset in `board.c`.
+- Enabling all bits in hypothetical PPC registers at `0x4008F07C` or `0x5008F07C` had no visible effect; the locations either read back zero or are unmapped.
+- The exact peripheral protection setup for this QEMU machine could not be determined, leaving the UART inaccessible.
+- Lacking documentation for the minimal BSP's hardware mapping makes it difficult to confirm the correct peripheral addresses.
+- Time constraints prevented deeper debugging of RT-Thread startup sequence and QEMU device settings.
+
+As a result, the RT-Thread boot message could not be displayed and the underlying cause remains unresolved.

--- a/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.c
+++ b/rt-thread/bsp/qemu-cortex-m7-test/drivers/board.c
@@ -2,12 +2,32 @@
 #include <rtthread.h>
 #include "board.h"
 
-#define UART0_BASE 0x40004000
+#define UART0_BASE 0x40004000U
 #define UART_DATA     (*(volatile uint32_t *)(UART0_BASE + 0x00))
 #define UART_STATE    (*(volatile uint32_t *)(UART0_BASE + 0x04))
 #define UART_CTRL     (*(volatile uint32_t *)(UART0_BASE + 0x08))
 #define UART_BAUDDIV  (*(volatile uint32_t *)(UART0_BASE + 0x10))
 #define UART_TX_FULL  (1U << 0)
+
+#define SAU_CTRL   (*(volatile uint32_t*)0xE000EDD0)
+
+static inline void __ISB(void)
+{
+    __asm volatile("isb" ::: "memory");
+}
+
+static inline void __DSB(void)
+{
+    __asm volatile("dsb" ::: "memory");
+}
+
+#define PPC_BASE           0x4008F000U
+#define AHB_PPC0_PRCTRL0   (*(volatile uint32_t*)(PPC_BASE + 0x000))
+#define APB_PPC0_PRCTRL    (*(volatile uint32_t*)(PPC_BASE + 0x07C))
+
+#define SCC_BASE           0x4002F000U
+#define SCC_PERIPHCLKENSET (*(volatile uint32_t*)(SCC_BASE + 0x044))
+#define SCC_PERIPHRSTENCLR (*(volatile uint32_t*)(SCC_BASE + 0x048))
 
 #define SYST_CSR   (*(volatile uint32_t*)0xE000E010)
 #define SYST_RVR   (*(volatile uint32_t*)0xE000E014)
@@ -18,10 +38,29 @@
 #endif
 static uint32_t SystemCoreClock = SYSTEM_CORE_CLOCK;
 
+static void sau_disable_and_secure_all(void)
+{
+    SAU_CTRL = 0;
+    __ISB();
+    __DSB();
+}
+
+static void ppc_open_all(void)
+{
+    AHB_PPC0_PRCTRL0 = 0xFFFFFFFFU;
+    APB_PPC0_PRCTRL  = 0xFFFFFFFFU;
+}
+
+static void uart0_gate_and_reset(void)
+{
+    SCC_PERIPHCLKENSET = 1U;
+    SCC_PERIPHRSTENCLR = 1U;
+}
+
 static void uart0_init(void)
 {
-    UART_BAUDDIV = (25000000 / 115200);
-    UART_CTRL = (1 << 0);
+    UART_BAUDDIV = (25000000 / 115200) - 1; /* 25 MHz PCLK */
+    UART_CTRL = 1U; /* TX_EN */
 }
 
 void rt_hw_console_output(const char *str)
@@ -51,6 +90,9 @@ void rt_hw_board_init(void)
     rt_system_heap_init(HEAP_BEGIN, HEAP_END);
 #endif
 
+    sau_disable_and_secure_all();
+    ppc_open_all();
+    uart0_gate_and_reset();
     uart0_init();
 
     SYST_RVR = SystemCoreClock / RT_TICK_PER_SECOND - 1;


### PR DESCRIPTION
## Summary
- attempt to open peripheral protection controller and clock gates in the Cortex‑M7 test BSP
- document additional debugging steps for missing serial output

## Testing
- `scons -C rt-thread/bsp/qemu-cortex-m7-test -j$(nproc)`
- `timeout 5 qemu-system-arm -M mps2-an500 -kernel rt-thread/bsp/qemu-cortex-m7-test/rtthread.bin -nographic -serial mon:stdio` *(still no output)*
